### PR TITLE
unit Number aka unit name is showned now for properties details

### DIFF
--- a/src/app/(without-navigation)/owners/properties/add-property/single-unit-option/form.tsx
+++ b/src/app/(without-navigation)/owners/properties/add-property/single-unit-option/form.tsx
@@ -232,13 +232,16 @@ export default function SingleUnitOptionForm({
                       onChange={(event) =>
                         field.handleChange(event.target.value)
                       }
-                      placeholder="e.g., Main Unit, 101, A"
+                      placeholder="Optional - defaults to 'Unit 1'"
                       className={cn(
                         "w-full",
                         field.state.meta.errors.length > 0 &&
                           "border-destructive"
                       )}
                     />
+                    <FieldDescription>
+                      Leave empty to auto-generate "Unit 1"
+                    </FieldDescription>
                     <FieldError errors={field.state.meta.errors} />
                   </Field>
                 )}

--- a/src/app/(without-navigation)/owners/properties/details/property-details.tsx
+++ b/src/app/(without-navigation)/owners/properties/details/property-details.tsx
@@ -80,6 +80,17 @@ export default function PropertyDetails({ property }: PropertyDetailsProps) {
               <div className="flex flex-wrap items-center gap-6 text-lg">
                 {!isMultiUnit ? (
                   <>
+                    {/* Unit Name/Number */}
+                    {singleUnit.unitNumber && (
+                      <>
+                        <div className="flex items-center gap-2">
+                          <Building2 className="size-5 text-muted-foreground" />
+                          <span className="font-medium">{singleUnit.unitNumber}</span>
+                        </div>
+                        <Separator orientation="vertical" className="h-6" />
+                      </>
+                    )}
+
                     <div className="flex items-center gap-2 font-semibold">
                       <DollarSign className="size-5" />
                       <span>

--- a/src/app/actions/properties.ts
+++ b/src/app/actions/properties.ts
@@ -370,7 +370,10 @@ export const updatePropertyDraft = async (
 
 // Schema for unit data
 const unitDataSchema = z.object({
-  unitNumber: z.string().trim(),
+  unitNumber: z
+    .string()
+    .transform((val) => val.trim())
+    .transform((val) => val || "Unit 1"), // Auto-generate "Unit 1" if empty
   bedrooms: z.string().min(1),
   bathrooms: z.string().min(1),
   rentAmount: z.string().trim(),

--- a/src/dal/properties.ts
+++ b/src/dal/properties.ts
@@ -376,12 +376,24 @@ export const createUnitsDAL = cache(
         data: createdUnits,
       };
     } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      // Detect unique constraint violations
+      if (
+        errorMessage.includes("23505") ||
+        errorMessage.includes("unique constraint") ||
+        errorMessage.includes("duplicate key")
+      ) {
+        return {
+          success: false,
+          message:
+            "A unit with this name already exists for this property. Please choose a different name.",
+        };
+      }
+
       return {
         success: false,
-        message:
-          error instanceof Error
-            ? error.message
-            : "Failed to create units. Please try again.",
+        message: errorMessage || "Failed to create units. Please try again.",
       };
     }
   }


### PR DESCRIPTION
There's a confusion between the property name that belongs to the properties table and the unitNumber that belongs to the units table. We just fixed the issue related to the units table. We'll need another PR to fix kinda add as a feat the properties name + description